### PR TITLE
Fix behavior of squash-title broken in last commit

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -53,7 +53,7 @@ export class Input {
     }
 
     if (core.getInput('squash-title') === 'true') {
-      this.squashCommitTitle = "${pullRequest.title} (#${pullRequest.number})"
+      this.squashCommitTitle = "${pull_request.title} (#${pull_request.number})"
       this.squashCommitMessage = "\n"
     } else{
       this.squashCommitTitle = core.getInput('squash-commit-title') || undefined


### PR DESCRIPTION
Sorry, in #1373 I got the casing for the templating for squash-title incorrect, this fixes the issue.