### PR TITLE
Bump NodeJS version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,5 +55,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,23 +1413,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/cli/node_modules/@whatwg-node/fetch": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.3.2.tgz",
-      "integrity": "sha512-Bs5zAWQs0tXsLa4mRmLw7Psps1EN78vPtgcLpw3qPY8s6UYPUM67zFZ9cy+7tZ64PXhfwzxJn+m7RH2Lq48RNQ==",
-      "dev": true,
-      "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
-        "abort-controller": "^3.0.0",
-        "busboy": "^1.6.0",
-        "event-target-polyfill": "^0.0.3",
-        "form-data-encoder": "^1.7.1",
-        "formdata-node": "^4.3.1",
-        "node-fetch": "^2.6.7",
-        "undici": "^5.8.0",
-        "web-streams-polyfill": "^3.2.0"
-      }
-    },
     "node_modules/@graphql-codegen/core": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.6.2.tgz",
@@ -1576,6 +1559,22 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
+      "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "abort-controller": "^3.0.0",
+        "busboy": "^1.6.0",
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^5.10.0",
+        "web-streams-polyfill": "^3.2.0"
+      }
+    },
     "node_modules/@graphql-tools/batch-execute": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.6.tgz",
@@ -1655,6 +1654,22 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
+      "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "abort-controller": "^3.0.0",
+        "busboy": "^1.6.0",
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^5.10.0",
+        "web-streams-polyfill": "^3.2.0"
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
@@ -1840,6 +1855,22 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
+      "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "abort-controller": "^3.0.0",
+        "busboy": "^1.6.0",
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^5.10.0",
+        "web-streams-polyfill": "^3.2.0"
       }
     },
     "node_modules/@graphql-tools/utils": {
@@ -2334,13 +2365,13 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2789,9 +2820,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2997,18 +3028,19 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
-      "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.3.2.tgz",
+      "integrity": "sha512-Bs5zAWQs0tXsLa4mRmLw7Psps1EN78vPtgcLpw3qPY8s6UYPUM67zFZ9cy+7tZ64PXhfwzxJn+m7RH2Lq48RNQ==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "abort-controller": "^3.0.0",
         "busboy": "^1.6.0",
+        "event-target-polyfill": "^0.0.3",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
-        "undici": "^5.10.0",
+        "undici": "^5.8.0",
         "web-streams-polyfill": "^3.2.0"
       }
     },
@@ -3826,14 +3858,17 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone": {
@@ -6691,9 +6726,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -8818,9 +8853,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -9368,12 +9403,12 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "dev": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -10425,25 +10460,6 @@
         "tslib": "^2.4.0",
         "yaml": "^1.10.0",
         "yargs": "^17.0.0"
-      },
-      "dependencies": {
-        "@whatwg-node/fetch": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.3.2.tgz",
-          "integrity": "sha512-Bs5zAWQs0tXsLa4mRmLw7Psps1EN78vPtgcLpw3qPY8s6UYPUM67zFZ9cy+7tZ64PXhfwzxJn+m7RH2Lq48RNQ==",
-          "dev": true,
-          "requires": {
-            "@peculiar/webcrypto": "^1.4.0",
-            "abort-controller": "^3.0.0",
-            "busboy": "^1.6.0",
-            "event-target-polyfill": "^0.0.3",
-            "form-data-encoder": "^1.7.1",
-            "formdata-node": "^4.3.1",
-            "node-fetch": "^2.6.7",
-            "undici": "^5.8.0",
-            "web-streams-polyfill": "^3.2.0"
-          }
-        }
       }
     },
     "@graphql-codegen/core": {
@@ -10563,6 +10579,24 @@
         "@graphql-tools/utils": "8.12.0",
         "@whatwg-node/fetch": "^0.4.0",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@whatwg-node/fetch": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
+          "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+          "dev": true,
+          "requires": {
+            "@peculiar/webcrypto": "^1.4.0",
+            "abort-controller": "^3.0.0",
+            "busboy": "^1.6.0",
+            "form-data-encoder": "^1.7.1",
+            "formdata-node": "^4.3.1",
+            "node-fetch": "^2.6.7",
+            "undici": "^5.10.0",
+            "web-streams-polyfill": "^3.2.0"
+          }
+        }
       }
     },
     "@graphql-tools/batch-execute": {
@@ -10629,6 +10663,24 @@
         "@graphql-tools/utils": "8.12.0",
         "@whatwg-node/fetch": "^0.4.0",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@whatwg-node/fetch": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
+          "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+          "dev": true,
+          "requires": {
+            "@peculiar/webcrypto": "^1.4.0",
+            "abort-controller": "^3.0.0",
+            "busboy": "^1.6.0",
+            "form-data-encoder": "^1.7.1",
+            "formdata-node": "^4.3.1",
+            "node-fetch": "^2.6.7",
+            "undici": "^5.10.0",
+            "web-streams-polyfill": "^3.2.0"
+          }
+        }
       }
     },
     "@graphql-tools/graphql-file-loader": {
@@ -10781,6 +10833,24 @@
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.11",
         "ws": "^8.3.0"
+      },
+      "dependencies": {
+        "@whatwg-node/fetch": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
+          "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+          "dev": true,
+          "requires": {
+            "@peculiar/webcrypto": "^1.4.0",
+            "abort-controller": "^3.0.0",
+            "busboy": "^1.6.0",
+            "form-data-encoder": "^1.7.1",
+            "formdata-node": "^4.3.1",
+            "node-fetch": "^2.6.7",
+            "undici": "^5.10.0",
+            "web-streams-polyfill": "^3.2.0"
+          }
+        }
       }
     },
     "@graphql-tools/utils": {
@@ -11168,13 +11238,13 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@nodelib/fs.scandir": {
@@ -11583,9 +11653,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -11703,18 +11773,19 @@
       "dev": true
     },
     "@whatwg-node/fetch": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
-      "integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.3.2.tgz",
+      "integrity": "sha512-Bs5zAWQs0tXsLa4mRmLw7Psps1EN78vPtgcLpw3qPY8s6UYPUM67zFZ9cy+7tZ64PXhfwzxJn+m7RH2Lq48RNQ==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "abort-controller": "^3.0.0",
         "busboy": "^1.6.0",
+        "event-target-polyfill": "^0.0.3",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.7",
-        "undici": "^5.10.0",
+        "undici": "^5.8.0",
         "web-streams-polyfill": "^3.2.0"
       }
     },
@@ -12317,13 +12388,13 @@
       "dev": true
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -14447,9 +14518,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -16040,9 +16111,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -16439,12 +16510,12 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",


### PR DESCRIPTION
This PRs bumps the NodeJS version to 16 since NodeJS 12 is deprecated, [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) you can find more info.

Changes were done as follows:
- Modify `action.yml` by bumping the node version
- Run `npm update` using
  - `node --version` = `v16.18.0`
  - `npm --version` = `8.19.2`

Signed-off-by: Carlos Rodríguez Hernández <carlosrh@vmware.com>