### PR TITLE
fix: reverse condition. function as originally intended

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53202,7 +53202,7 @@ class AutomergeAction {
         const baseBranch = pullRequest.base.ref;
         const hasRequiredStatusChecks = await (0, helpers_1.branchHasRequiredStatusChecks)(this.octokit, baseBranch);
         // Only auto-merge if there is at least one required status check.
-        if (hasRequiredStatusChecks) {
+        if (!hasRequiredStatusChecks) {
             core.info(`Base branch '${baseBranch}' of pull request ${number} is not sufficiently protected.`);
             await this.disableAutoMerge(pullRequest);
             return;

--- a/src/automerge-action.ts
+++ b/src/automerge-action.ts
@@ -179,7 +179,7 @@ export class AutomergeAction {
     const hasRequiredStatusChecks = await branchHasRequiredStatusChecks(this.octokit, baseBranch)
 
     // Only auto-merge if there is at least one required status check.
-    if (hasRequiredStatusChecks) {
+    if (!hasRequiredStatusChecks) {
       core.info(`Base branch '${baseBranch}' of pull request ${number} is not sufficiently protected.`)
       await this.disableAutoMerge(pullRequest)
       return


### PR DESCRIPTION
i believe https://github.com/reitermarkus/automerge/pull/4031/files#diff-4e0e66b64752cd230eb5f974fc26d665a896ab655d51b75bebf2bf67e1490ab5R182 accidentally reversed the logic so that auto merge is enabled on only branches without required checks

i also ran some manual checks to make sure that this is working as intended
- tested that a PR with required checks from **branch protection** succeeds
- tested that a PR with required checks from **rules** succeeds
- tested that a PR without required checks from **branch protection** or **rules** fails
- tested that a PR with required checks from **branch protection** and **rules** succeeds